### PR TITLE
Add LM Studio chat demo

### DIFF
--- a/docs/guides/crews/chat-demo.mdx
+++ b/docs/guides/crews/chat-demo.mdx
@@ -1,0 +1,28 @@
+---
+title: Local Chat Demo
+description: Chat with a local model through LM Studio using CrewAI.
+icon: message-text
+---
+
+This short example shows how to run CrewAI completely offline by connecting to LM Studio's OpenAI-compatible API. You'll run a local model and chat with it directly from the `chat_demo.py` script.
+
+## 1. Start LM Studio
+
+1. Install LM Studio and download a model.
+2. Launch its API server. It usually listens on `http://localhost:1234/v1`.
+
+## 2. Set the environment variables
+
+```bash
+export OPENAI_API_KEY=lmstudio            # any placeholder value
+export OPENAI_API_BASE=http://localhost:1234/v1
+export OPENAI_MODEL_NAME=openai/your-model
+```
+
+## 3. Run the chat demo
+
+```bash
+python examples/chat_demo.py
+```
+
+Type a message when prompted and you'll receive a response from your local model. Type `exit` to stop the conversation.

--- a/examples/chat_demo.py
+++ b/examples/chat_demo.py
@@ -1,0 +1,32 @@
+import os
+from crewai import Agent, LLM
+
+
+def main():
+    llm = LLM(
+        model=os.getenv("OPENAI_MODEL_NAME", "openai/your-model"),
+        api_key=os.getenv("OPENAI_API_KEY", "lmstudio"),
+        base_url=os.getenv("OPENAI_API_BASE", "http://localhost:1234/v1"),
+    )
+
+    assistant = Agent(
+        role="Local Chat Assistant",
+        goal="Answer user questions",
+        backstory="Runs locally using LM Studio",
+        llm=llm,
+    )
+
+    messages = []
+    print("Start chatting with the local model. Type 'exit' to quit.")
+    while True:
+        user = input("You: ")
+        if user.lower() in {"exit", "quit"}:
+            break
+        messages.append({"role": "user", "content": user})
+        reply = assistant.llm.call(messages=messages)
+        messages.append({"role": "assistant", "content": reply})
+        print(f"Assistant: {reply}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
     - Drafting emails with LangGraph: https://github.com/joaomdmoura/crewAI-examples/tree/main/CrewAI-LangGraph"
     - Landing Page Generator: https://github.com/joaomdmoura/crewAI-examples/tree/main/landing_page_generator"
     - Prepare for meetings: https://github.com/joaomdmoura/crewAI-examples/tree/main/prep-for-a-meeting"
+    - Local Chat Demo: 'guides/crews/chat-demo.mdx'
   - Telemetry: 'telemetry/Telemetry.md'
   - Change Log: 'https://github.com/crewAIInc/crewAI/releases'
 


### PR DESCRIPTION
## Summary
- add `chat_demo.py` to demonstrate local chat with LM Studio
- document how to run the demo via `chat-demo.mdx`
- link the documentation page in mkdocs navigation

## Testing
- `uv run pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684b630d69f0832f8cf7d53d235cc2d0